### PR TITLE
Switch Honeycomb-facing trace schema

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -35,11 +35,11 @@ type Annotation struct {
 
 // Span is the format of trace events that Honeycomb accepts
 type Span struct {
-	TraceID     string       `json:"traceId"`
+	TraceID     string       `json:"trace.trace_id"`
 	Name        string       `json:"name"`
-	ID          string       `json:"id"`
-	ParentID    string       `json:"parentId,omitempty"`
-	DurationMs  int          `json:"durationMs,omitempty"`
+	ID          string       `json:"trace.span_id"`
+	ParentID    string       `json:"trace.parent_id,omitempty"`
+	DurationMs  int          `json:"duration_ms,omitempty"`
 	Timestamp   time.Time    `json:"timestamp,omitempty"`
 	Annotations []Annotation `json:"annotations,omitempty"`
 }

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -174,12 +174,12 @@ func TestHoneycombOutput(t *testing.T) {
 
 	assert.Equal(1, len(mockHoneycomb.Events()))
 	assert.Equal(map[string]interface{}{
-		"traceId":       span.SpanContext().TraceID.String(),
-		"id":            span.SpanContext().SpanID.String(),
-		"name":          "mySpan",
-		"attributeName": "attributeValue",
-		"durationMs":    1,
-		"timestamp":     mockHoneycomb.Events()[0].Timestamp, // This timestamp test isn't useful, but does let us check the whole struct
+		"trace.trace_id": span.SpanContext().TraceID.String(),
+		"trace.span_id":  span.SpanContext().SpanID.String(),
+		"name":           "mySpan",
+		"attributeName":  "attributeValue",
+		"duration_ms":    1,
+		"timestamp":      mockHoneycomb.Events()[0].Timestamp, // This timestamp test isn't useful, but does let us check the whole struct
 	}, mockHoneycomb.Events()[0].Fields())
 	assert.Equal(mockHoneycomb.Events()[0].Dataset, "test")
 }


### PR DESCRIPTION
Right now the Honeycomb UI supports multiple trace schemas, but not
mixing and matching schemas in the same dataset. Change the exporter to
use the same schema as Honeycomb beelines.