### PR TITLE
Expose SampleRate on the event builder

### DIFF
--- a/Honeycombio.md
+++ b/Honeycombio.md
@@ -44,7 +44,14 @@ func main() {
 exporter := honeycomb.NewExporter("YOUR-HONEYCOMB-WRITE-KEY", "YOUR-DATASET-NAME")
 defer exporter.Close()
 
-    trace.RegisterExporter(exporter)
+sampleRate := 0.5
+trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(sampleRate)})
+// If you use the Open Census Probability Sampler, be sure to pass that sampleRate to the exporter
+// so that Honeycomb can pick it up and make sure we handle your sampling properly.
+// Note: The Probability Sampler uses a fraction, whereas Honeycomb uses an integer, which is the inverse of that fraction.
+exporter.SampleRate = sampleRate
+
+trace.RegisterExporter(exporter)
 
 }
 {{</highlight>}}

--- a/example/main.go
+++ b/example/main.go
@@ -78,38 +78,3 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 
 	return bytes.ToUpper(in), nil
 }
-	_, span := trace.StartSpan(ctx, "processLine")
-	defer span.End()
-
-	return bytes.ToUpper(in), nil
-}
-
-// package main
-
-// import (
-// 	"context"
-// 	"fmt"
-// 	"time"
-
-// 	"github.com/honeycombio/opencensus-exporter/honeycomb"
-// 	"go.opencensus.io/trace"
-// )
-
-// func main() {
-// 	exporter := honeycomb.NewExporter("44b49dc4ccb387b11a57fab6cf731c0c", "sampled-traces")
-// 	defer exporter.Close()
-
-// 	trace.RegisterExporter(exporter)
-
-// 	sampleRate := 0.5
-// 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(sampleRate)})
-// 	exporter.SampleRate = sampleRate
-
-// 	for i := 0; i < 5; i++ {
-// 		_, span := trace.StartSpan(context.Background(), fmt.Sprintf("sample-%d", i))
-// 		span.Annotate([]trace.Attribute{trace.Int64Attribute("invocations", 1)}, "Invoked it")
-// 		span.End()
-// 		<-time.After(10 * time.Millisecond)
-// 	}
-// 	<-time.After(500 * time.Millisecond)
-// }

--- a/example/main.go
+++ b/example/main.go
@@ -21,12 +21,12 @@ func main() {
 
 	br := bufio.NewReader(os.Stdin)
 
-	sampleRate := 0.5
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(sampleRate)})
+	sampleFraction := 0.5
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(sampleFraction)})
 	// If you use the Open Census Probability Sampler, be sure to pass that sampleRate to the exporter
 	// so that Honeycomb can pick it up and make sure we handle your sampling properly.
 	// Note: The Probability Sampler uses a fraction, whereas Honeycomb uses an integer, which is the inverse of that fraction.
-	exporter.SampleRate = sampleRate
+	exporter.SampleFraction = sampleFraction
 
 	// repl is the read, evaluate, print, loop
 	for {

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -24,8 +24,8 @@ import (
 
 // Exporter is an implementation of trace.Exporter that uploads a span to Honeycomb
 type Exporter struct {
-	Builder    *libhoney.Builder
-	SampleRate float64
+	Builder        *libhoney.Builder
+	SampleFraction float64
 }
 
 // Annotation represents an annotation with a value and a timestamp.
@@ -63,14 +63,17 @@ func NewExporter(writeKey, dataset string) *Exporter {
 	builder.Dataset = dataset
 	// default sample reate is 1: aka no sampling.
 	// set sampleRate on the exporter to be the sample rate given to the ProbabilitySampler if used.
-	return &Exporter{builder, 1}
+	return &Exporter{
+		Builder:        builder,
+		SampleFraction: 1,
+	}
 }
 
 // ExportSpan exports a span to Honeycomb
 func (e *Exporter) ExportSpan(sd *trace.SpanData) {
 	ev := e.Builder.NewEvent()
-	if e.SampleRate != 0 {
-		ev.SampleRate = uint(1 / e.SampleRate)
+	if e.SampleFraction != 0 {
+		ev.SampleRate = uint(1 / e.SampleFraction)
 	}
 	ev.Timestamp = sd.StartTime
 	hs := honeycombSpan(sd)


### PR DESCRIPTION
This exposes the sample rate on the event builder.

OpenCensus only calls ExportSpan on the spans that have made it through the ProbabilitySampler and will actually be sent up to Honeycomb.
