### PR TITLE
Add optional ServiceName attribute

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -28,6 +28,8 @@ func main() {
 	// Note: The Probability Sampler uses a fraction, whereas Honeycomb uses an integer, which is the inverse of that fraction.
 	exporter.SampleFraction = sampleFraction
 
+	exporter.ServiceName = "honeycomb-example"
+
 	// repl is the read, evaluate, print, loop
 	for {
 		if err := readEvaluateProcess(br); err != nil {

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -26,6 +26,10 @@ import (
 type Exporter struct {
 	Builder        *libhoney.Builder
 	SampleFraction float64
+	// Service Name identifies your application. While optional, setting this
+	// field is extremely valuable when you instrument multiple services. If set
+	// it will be added to all events as `service_name`
+	ServiceName string
 }
 
 // Annotation represents an annotation with a value and a timestamp.
@@ -66,6 +70,7 @@ func NewExporter(writeKey, dataset string) *Exporter {
 	return &Exporter{
 		Builder:        builder,
 		SampleFraction: 1,
+		ServiceName:    "",
 	}
 }
 
@@ -74,6 +79,9 @@ func (e *Exporter) ExportSpan(sd *trace.SpanData) {
 	ev := e.Builder.NewEvent()
 	if e.SampleFraction != 0 {
 		ev.SampleRate = uint(1 / e.SampleFraction)
+	}
+	if e.ServiceName != "" {
+		ev.AddField("service_name", e.ServiceName)
 	}
 	ev.Timestamp = sd.StartTime
 	hs := honeycombSpan(sd)

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -160,6 +160,7 @@ func TestHoneycombOutput(t *testing.T) {
 	mockHoneycomb := &libhoney.MockOutput{}
 	assert := assert.New(t)
 	exporter := NewExporter("test", "test")
+	exporter.ServiceName = "honeycomb-test"
 
 	libhoney.Init(libhoney.Config{
 		Output: mockHoneycomb,
@@ -180,6 +181,7 @@ func TestHoneycombOutput(t *testing.T) {
 		"attributeName":  "attributeValue",
 		"duration_ms":    1,
 		"timestamp":      mockHoneycomb.Events()[0].Timestamp, // This timestamp test isn't useful, but does let us check the whole struct
+		"service_name":   "honeycomb-test",
 	}, mockHoneycomb.Events()[0].Fields())
 	assert.Equal(mockHoneycomb.Events()[0].Dataset, "test")
 }


### PR DESCRIPTION
This change adds an optional ServiceName attribute to the exporter struct.
If set, it will be added to all events as `service_name`.

In the OpenCensus-Honeycomb example app, that ends up looking like this in our trace view:
![image](https://user-images.githubusercontent.com/10929533/47880011-5ba84500-dddf-11e8-9478-5d1125827a5d.png)
