### PR TITLE
initialize libhoney before use in order to get a functional Builder

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -71,10 +71,9 @@ func NewExporter(writeKey, dataset string) *Exporter {
 		Dataset:  dataset,
 	})
 	builder := libhoney.NewBuilder()
-	builder.WriteKey = writeKey
-	builder.Dataset = dataset
 	// default sample reate is 1: aka no sampling.
-	// set sampleRate on the exporter to be the sample rate given to the ProbabilitySampler if used.
+	// set sampleRate on the exporter to be the sample rate given to the
+	// ProbabilitySampler if used.
 	return &Exporter{
 		Builder:        builder,
 		SampleFraction: 1,
@@ -109,7 +108,6 @@ func (e *Exporter) ExportSpan(sd *trace.SpanData) {
 	if sd.Status.Message != "" {
 		ev.AddField("status_description", sd.Status.Message)
 	}
-
 	ev.SendPresampled()
 }
 

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -63,8 +63,13 @@ func (e *Exporter) Close() {
 // Don't have a Honeycomb account? Sign up at https://ui.honeycomb.io/signup
 func NewExporter(writeKey, dataset string) *Exporter {
 	// Developer note: bump this with each release
-	versionStr := "0.0.4"
+	versionStr := "0.0.5"
 	libhoney.UserAgentAddition = "Honeycomb-OpenCensus-exporter/" + versionStr
+
+	libhoney.Init(libhoney.Config{
+		WriteKey: writeKey,
+		Dataset:  dataset,
+	})
 	builder := libhoney.NewBuilder()
 	builder.WriteKey = writeKey
 	builder.Dataset = dataset

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -159,12 +159,15 @@ func TestExport(t *testing.T) {
 func TestHoneycombOutput(t *testing.T) {
 	mockHoneycomb := &libhoney.MockOutput{}
 	assert := assert.New(t)
-	exporter := NewExporter("test", "test")
+	exporter := NewExporter("overridden", "overridden")
 	exporter.ServiceName = "honeycomb-test"
 
 	libhoney.Init(libhoney.Config{
-		Output: mockHoneycomb,
+		WriteKey: "test",
+		Dataset:  "test",
+		Output:   mockHoneycomb,
 	})
+	exporter.Builder = libhoney.NewBuilder()
 
 	trace.RegisterExporter(exporter)
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})


### PR DESCRIPTION
When libhoney is not initialized, the Builder returned is not guaranteed to be functional. While this used to work, with a newer version of libhoney, the Builder returned by an unitialized libhoney doesn't have the writekey set. This change explicitly calls `libhoney.Init()` in order to ensure that all the defaults are well established before starting to create events.