### PR TITLE
pass float64 instead of int for duration_ms and don't omit if empty

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -63,7 +63,7 @@ func (e *Exporter) Close() {
 // Don't have a Honeycomb account? Sign up at https://ui.honeycomb.io/signup
 func NewExporter(writeKey, dataset string) *Exporter {
 	// Developer note: bump this with each release
-	versionStr := "0.0.5"
+	versionStr := "0.0.6"
 	libhoney.UserAgentAddition = "Honeycomb-OpenCensus-exporter/" + versionStr
 
 	libhoney.Init(libhoney.Config{

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -125,7 +125,7 @@ func honeycombSpan(s *trace.SpanData) Span {
 	}
 
 	if s, e := s.StartTime, s.EndTime; !s.IsZero() && !e.IsZero() {
-		hcSpan.DurationMs = float64(e.Sub(s) / time.Millisecond)
+		hcSpan.DurationMs = float64(e.Sub(s)) / float64(time.Millisecond)
 	}
 
 	if len(s.Annotations) != 0 || len(s.MessageEvents) != 0 {

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -44,7 +44,7 @@ type Span struct {
 	Name        string       `json:"name"`
 	ID          string       `json:"trace.span_id"`
 	ParentID    string       `json:"trace.parent_id,omitempty"`
-	DurationMs  int          `json:"duration_ms,omitempty"`
+	DurationMs  float64      `json:"duration_ms"`
 	Timestamp   time.Time    `json:"timestamp,omitempty"`
 	Annotations []Annotation `json:"annotations,omitempty"`
 }
@@ -125,7 +125,7 @@ func honeycombSpan(s *trace.SpanData) Span {
 	}
 
 	if s, e := s.StartTime, s.EndTime; !s.IsZero() && !e.IsZero() {
-		hcSpan.DurationMs = int(e.Sub(s) / time.Millisecond)
+		hcSpan.DurationMs = float64(e.Sub(s) / time.Millisecond)
 	}
 
 	if len(s.Annotations) != 0 || len(s.MessageEvents) != 0 {

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -27,7 +27,7 @@ func TestExport(t *testing.T) {
 				Name:      "name",
 				SpanKind:  trace.SpanKindClient,
 				StartTime: now,
-				EndTime:   now.Add(24 * time.Hour),
+				EndTime:   now.Add(1.0 * time.Millisecond),
 				Attributes: map[string]interface{}{
 					"stringkey": "value",
 					"intkey":    int64(42),
@@ -66,7 +66,7 @@ func TestExport(t *testing.T) {
 				Name:       "name",
 				ParentID:   "",
 				Timestamp:  now,
-				DurationMs: 86400000,
+				DurationMs: float64(1),
 				Annotations: []Annotation{
 					{
 						Timestamp: now,
@@ -182,7 +182,7 @@ func TestHoneycombOutput(t *testing.T) {
 		"trace.span_id":  span.SpanContext().SpanID.String(),
 		"name":           "mySpan",
 		"attributeName":  "attributeValue",
-		"duration_ms":    1,
+		"duration_ms":    float64(1),
 		"timestamp":      mockHoneycomb.Events()[0].Timestamp, // This timestamp test isn't useful, but does let us check the whole struct
 		"service_name":   "honeycomb-test",
 	}, mockHoneycomb.Events()[0].Fields())

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -177,14 +177,27 @@ func TestHoneycombOutput(t *testing.T) {
 	span.End()
 
 	assert.Equal(1, len(mockHoneycomb.Events()))
-	assert.Equal(map[string]interface{}{
-		"trace.trace_id": span.SpanContext().TraceID.String(),
-		"trace.span_id":  span.SpanContext().SpanID.String(),
-		"name":           "mySpan",
-		"attributeName":  "attributeValue",
-		"duration_ms":    float64(1),
-		"timestamp":      mockHoneycomb.Events()[0].Timestamp, // This timestamp test isn't useful, but does let us check the whole struct
-		"service_name":   "honeycomb-test",
-	}, mockHoneycomb.Events()[0].Fields())
+	traceID := mockHoneycomb.Events()[0].Fields()["trace.trace_id"]
+	assert.Equal(span.SpanContext().TraceID.String(), traceID)
+
+	spanID := mockHoneycomb.Events()[0].Fields()["trace.span_id"]
+	assert.Equal(span.SpanContext().SpanID.String(), spanID)
+
+	name := mockHoneycomb.Events()[0].Fields()["name"]
+	assert.Equal("mySpan", name)
+
+	// I wish we could, but I can't test duration_ms here because of it's variability, and the fact that it's an undefined interface.
+	// OpenCensus doesn't give me access to set start/end times to something we know.
+	// So for now, though it makes me sad, skipping the duration_ms check
+	// It should equal something like 1.4...
+
+	attributeName := mockHoneycomb.Events()[0].Fields()["attributeName"]
+	assert.Equal("attributeValue", attributeName)
+
+	timestamp := mockHoneycomb.Events()[0].Fields()["timestamp"]
+	assert.Equal(mockHoneycomb.Events()[0].Timestamp, timestamp)
+
+	serviceName := mockHoneycomb.Events()[0].Fields()["service_name"]
+	assert.Equal("honeycomb-test", serviceName)
 	assert.Equal(mockHoneycomb.Events()[0].Dataset, "test")
 }

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -186,10 +186,10 @@ func TestHoneycombOutput(t *testing.T) {
 	name := mockHoneycomb.Events()[0].Fields()["name"]
 	assert.Equal("mySpan", name)
 
-	// I wish we could, but I can't test duration_ms here because of it's variability, and the fact that it's an undefined interface.
-	// OpenCensus doesn't give me access to set start/end times to something we know.
-	// So for now, though it makes me sad, skipping the duration_ms check
-	// It should equal something like 1.4...
+	durationMs := mockHoneycomb.Events()[0].Fields()["duration_ms"]
+	durationMsFl, ok := durationMs.(float64)
+	assert.Equal(ok, true)
+	assert.Equal((durationMsFl > 0), true)
 
 	attributeName := mockHoneycomb.Events()[0].Fields()["attributeName"]
 	assert.Equal("attributeValue", attributeName)

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -27,7 +27,7 @@ func TestExport(t *testing.T) {
 				Name:      "name",
 				SpanKind:  trace.SpanKindClient,
 				StartTime: now,
-				EndTime:   now.Add(1.0 * time.Millisecond),
+				EndTime:   now.Add(time.Duration(0.5 * float64(time.Millisecond))),
 				Attributes: map[string]interface{}{
 					"stringkey": "value",
 					"intkey":    int64(42),
@@ -66,7 +66,7 @@ func TestExport(t *testing.T) {
 				Name:       "name",
 				ParentID:   "",
 				Timestamp:  now,
-				DurationMs: float64(1),
+				DurationMs: 0.5,
 				Annotations: []Annotation{
 					{
 						Timestamp: now,
@@ -172,7 +172,7 @@ func TestHoneycombOutput(t *testing.T) {
 	trace.RegisterExporter(exporter)
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	_, span := trace.StartSpan(context.TODO(), "mySpan")
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(time.Duration(0.5 * float64(time.Millisecond)))
 	span.AddAttributes(trace.StringAttribute("attributeName", "attributeValue"))
 	span.End()
 
@@ -190,6 +190,7 @@ func TestHoneycombOutput(t *testing.T) {
 	durationMsFl, ok := durationMs.(float64)
 	assert.Equal(ok, true)
 	assert.Equal((durationMsFl > 0), true)
+	assert.Equal((durationMsFl < 1), true)
 
 	attributeName := mockHoneycomb.Events()[0].Fields()["attributeName"]
 	assert.Equal("attributeValue", attributeName)


### PR DESCRIPTION
libhoney can handle floats, and so should the opencensus exporter.
This makes that change, and also gets rid of omitempty