### PR TITLE
add changelog, and bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,24 @@
 ## 1.0.0 2019-06-06
 
 Improvements:
+
 - Adds Changelog
-- Adds 1.0.0 release
 
 ## 0.0.6 2019-04-03
 
 Fixes:
+
 - Passes float64 instead of int for duration_ms
 - Includes duration_ms even if empty
 
 ## 0.0.5 2019-03-04
 
 Fixes:
+
 - Initializes libhoney before use in order to ensure a functional Builder
 
 ## 0.0.4 2018-11-02
 
 Improvements:
+
 - Sets user agent version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Honeycomb OpenCensus Exporter Changelog
+
+## 1.0.0 2019-06-06
+
+Improvements:
+- Adds Changelog
+- Adds 1.0.0 release
+
+## 0.0.6 2019-04-03
+
+Fixes:
+- Passes float64 instead of int for duration_ms
+- Includes duration_ms even if empty
+
+## 0.0.5 2019-03-04
+
+Fixes:
+- Initializes libhoney before use in order to ensure a functional Builder
+
+## 0.0.4 2018-11-02
+
+Improvements:
+- Sets user agent version

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -63,7 +63,7 @@ func (e *Exporter) Close() {
 // Don't have a Honeycomb account? Sign up at https://ui.honeycomb.io/signup
 func NewExporter(writeKey, dataset string) *Exporter {
 	// Developer note: bump this with each release
-	versionStr := "0.0.6"
+	versionStr := "1.0.0"
 	libhoney.UserAgentAddition = "Honeycomb-OpenCensus-exporter/" + versionStr
 
 	libhoney.Init(libhoney.Config{


### PR DESCRIPTION
Adds a Changelog and bumps the version number to 1.0.0 
(Which we probably should have been at a while ago)